### PR TITLE
feat: Add estimated reading time to posts

### DIFF
--- a/ik1.xml
+++ b/ik1.xml
@@ -261,6 +261,27 @@
   margin-top: 2.5rem;
 }
 
+.post-meta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  margin-top: 1rem;
+  color: var(--color-text);
+  font-size: .9rem;
+}
+
+.reading-time {
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+}
+
+.reading-time .i {
+  width: 16px;
+  height: 16px;
+}
+
 .post-comment{margin-top:2rem}
 
 .searchbox{pointer-events:var(--switch-search,none);opacity:var(--switch-search,0);transform:translate(-50%,var(--switch-search-position,0%));transition:opacity var(--transition-config),transform var(--transition-config);z-index:10;width:100%;max-width:500px;padding-left:2rem;padding-right:2rem;position:fixed;top:50%;left:50%}
@@ -1149,6 +1170,7 @@ a:hover::after {
             <symbol id='icon-brand-facebook' viewBox='0 0 24 24'><path d='M7 10v4h3v7h4v-7h3l1 -4h-4v-2a1 1 0 0 1 1 -1h3v-4h-3a5 5 0 0 0 -5 5v2h-3'/></symbol>
             <symbol id='icon-brand-reddit' viewBox='0 0 24 24'><path d='M12 8c2.648 0 5.028 .826 6.675 2.14a2.5 2.5 0 0 1 2.326 4.36c0 3.59 -4.03 6.5 -9 6.5c-4.875 0 -8.845 -2.8 -9 -6.294l-1 -.206a2.5 2.5 0 0 1 2.326 -4.36c1.646 -1.313 4.026 -2.14 6.674 -2.14z'/><path d='M12 8l1 -5l6 1'/><path d='M19 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0'/><circle cx='9' cy='13' r='.5' fill='currentColor'/><circle cx='15' cy='13' r='.5' fill='currentColor'/><path d='M10 17c.667 .333 1.333 .5 2 .5s1.333 -.167 2 -.5'/></symbol>
             <symbol id='icon-link' viewBox='0 0 24 24'><path d='M9 15l6 -6'/><path d='M11 6l.463 -.536a5 5 0 0 1 7.071 7.072l-.534 .464'/><path d='M13 18l-.397 .534a5.068 5.068 0 0 1 -7.127 0a4.972 4.972 0 0 1 0 -7.071l.524 -.463'/></symbol>
+            <symbol id='icon-clock' viewBox='0 0 24 24'><path d='M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0'/><path d='M12 7v5l3 3'/></symbol>
           </svg>
         </div>
       </b:includable>
@@ -1666,7 +1688,14 @@ a:hover::after {
         <header class='post-header'>
           <h1 class='post-title'><data:post.title.escaped/></h1>
           <b:if cond='data:view.isPost'>
-            <span class='post-date'><data:post.date/></span>
+            <div class='post-meta'>
+              <span class='post-date'><data:post.date/></span>
+              <span class='post-meta-divider'>•</span>
+              <div class='reading-time' title='Estimated reading time'>
+                <svg class='i'><use href='#icon-clock'/></svg>
+                <span id='reading-time-text'>…</span>
+              </div>
+            </div>
           </b:if>
         </header>
         <section class='post-body typography'>
@@ -1680,6 +1709,25 @@ a:hover::after {
           <b:include data='{ depth: 2, texts: { delete: data:skin.vars.t_delete, reply: data:skin.vars.t_reply } }' name='comment:main'/>
         </footer>
         <b:include name='postMetadataJSON'/>
+        <b:if cond='data:view.isPost'>
+          <script>
+          //<![CDATA[
+            (function() {
+              var postBody = document.querySelector('.post-body');
+              var readingTimeElement = document.getElementById('reading-time-text');
+
+              if (postBody && readingTimeElement) {
+                var text = postBody.textContent || postBody.innerText;
+                var wordCount = text.trim().split(/\s+/).length;
+                var wordsPerMinute = 225;
+                var readingTime = Math.ceil(wordCount / wordsPerMinute);
+
+                readingTimeElement.textContent = readingTime + ' min read';
+              }
+            })();
+          //]]>
+          </script>
+        </b:if>
       </b:includable>
       <b:includable id='widget:AdSense'>
         <b:include name='@ads'/>


### PR DESCRIPTION
This commit introduces a new feature to display the estimated reading time on blog posts.

- A clock icon has been added to the SVG sprite.
- The post header has been updated to include a placeholder for the reading time.
- A JavaScript snippet is added to post pages to:
  1. Count the words in the post body.
  2. Calculate the reading time based on an average of 225 words per minute.
  3. Display the result (e.g., "5 min read") in the post header.
- CSS has been added to style the new element.