### PR TITLE
refactor: Unify floating action button styles

### DIFF
--- a/ik1.xml
+++ b/ik1.xml
@@ -476,22 +476,29 @@
   position: fixed;
   bottom: 20px;
   right: 20px;
-  background: var(--primary, #000);
-  color: #fff;
-  padding: 0.6em 0.8em;
-  border-radius: 50%;
-  font-size: 1.2em;
-  text-align: center;
+  z-index: 1000;
   cursor: pointer;
+  background-color: var(--bg-post);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.3s ease;
-  z-index: 1000;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  transition: opacity 0.3s ease, background-color 0.2s, color 0.2s;
 }
 #back-to-top.show {
   opacity: 1;
   pointer-events: auto;
+}
+#back-to-top:hover, #dark-mode-toggle:hover {
+  background-color: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
 }
 #back-to-top:focus {
   outline: 2px solid var(--primary);
@@ -1171,6 +1178,7 @@ a:hover::after {
             <symbol id='icon-brand-reddit' viewBox='0 0 24 24'><path d='M12 8c2.648 0 5.028 .826 6.675 2.14a2.5 2.5 0 0 1 2.326 4.36c0 3.59 -4.03 6.5 -9 6.5c-4.875 0 -8.845 -2.8 -9 -6.294l-1 -.206a2.5 2.5 0 0 1 2.326 -4.36c1.646 -1.313 4.026 -2.14 6.674 -2.14z'/><path d='M12 8l1 -5l6 1'/><path d='M19 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0'/><circle cx='9' cy='13' r='.5' fill='currentColor'/><circle cx='15' cy='13' r='.5' fill='currentColor'/><path d='M10 17c.667 .333 1.333 .5 2 .5s1.333 -.167 2 -.5'/></symbol>
             <symbol id='icon-link' viewBox='0 0 24 24'><path d='M9 15l6 -6'/><path d='M11 6l.463 -.536a5 5 0 0 1 7.071 7.072l-.534 .464'/><path d='M13 18l-.397 .534a5.068 5.068 0 0 1 -7.127 0a4.972 4.972 0 0 1 0 -7.071l.524 -.463'/></symbol>
             <symbol id='icon-clock' viewBox='0 0 24 24'><path d='M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0'/><path d='M12 7v5l3 3'/></symbol>
+            <symbol id='icon-arrow-up' viewBox='0 0 24 24'><path d='M12 5l0 14'/><path d='M18 11l-6 -6'/><path d='M6 11l6 -6'/></symbol>
           </svg>
         </div>
       </b:includable>
@@ -2368,7 +2376,9 @@ a:hover::after {
   </script>
 </b:if>
 <!-- Back to Top Button -->
-<a aria-label='Back to top' href='#top' id='back-to-top'>&#8593;</a>
+<a aria-label='Back to top' href='#top' id='back-to-top'>
+  <svg class='i'><use href='#icon-arrow-up'/></svg>
+</a>
 <script>
 window.addEventListener(&#39;scroll&#39;, function() {
   const btn = document.getElementById(&#39;back-to-top&#39;);


### PR DESCRIPTION
This commit refactors the styling of the 'Back to Top' button to make it visually consistent with the 'Dark/Light Mode' toggle button.

- The CSS for the `#back-to-top` button has been updated to use the same colors, border, padding, and shadow as the dark mode toggle, ensuring it respects the theme's light and dark modes.
- A shared `:hover` style has been created for both buttons for a consistent user interaction.
- The text-based arrow (`&#8593;`) has been replaced with a proper SVG icon (`arrow-up`) from the theme's icon sprite for a cleaner look and better scalability.