### PR TITLE
Fix thumbnail and pagination issues in Blogger theme

### DIFF
--- a/ik1.xml
+++ b/ik1.xml
@@ -2367,11 +2367,11 @@ window.addEventListener(&#39;scroll&#39;, function() {
 }, { passive: true });
 </script>
 
-<b:if cond='data:view.isSearch and not data:posts'>
+<b:if cond='data:view.search.query and not data:posts'>
   <div id='no-results'>No results found. Try a different search.</div>
 </b:if>
 
-<script async='async' src='https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.3.2/lazysizes.min..js'/>
+<script async='async' src='https://cdnjs.cloudflare.com/ajax/libs/lazysizes/5.3.2/lazysizes.min.js'/>
 <script>
 //<![CDATA[
   function adaptPostBodyImages() {


### PR DESCRIPTION
This commit addresses two issues in the ik1.xml theme:

1.  Post thumbnails were not showing up due to a typo in the URL of the lazysizes lazy-loading script. The URL has been corrected.
2.  A 'No results found' message was incorrectly displayed on paginated pages. The condition for displaying this message has been made more specific to only show on actual search pages with no results.